### PR TITLE
Pull Request May 26 by MPT

### DIFF
--- a/docs/getting_started/installation_guide.rst
+++ b/docs/getting_started/installation_guide.rst
@@ -8,26 +8,54 @@ Installation Guide
 
 .. warning:: NGSolve support for the Anaconda Python Distribution is currently experimental, please do not use NGSolve installed in this way with OpenCMP until further notice.
 
-To begin using OpenCMP:
+**NOTE** 
+
+* Top-level directory refers to the highest level directory of OpenCMP. I.e., */users/.../opencmp*.
+
+Installing OpenCMP
+==================
 
 1) Clone the `GitHub repository <https://github.com/uw-comphys/opencmp>`_.
-2) Install the dependencies
-3) Install the :code:`opencmp` module using :code:`pip3 install .` from the top-level directory. 
-4) Optionally, run the unit tests using :code:`python -m pytest pytests/` from the top-level directory. Note,
+
+2) Install :code:`pip3`:
+
+    * Linux and WSL (Windows Subsystem for Linux) - Execute :code:`sudo apt install python3-pip`.
+    
+    * macOS - Install `Homebrew <https://brew.sh/>`_ via terminal. Then :code:`brew install python3`. This also installs pip3.
+    
+    * Windows - We recommend using `WSL <#supplementary-information>`_ (Windows Subsystem for Linux).
+
+3) Install the :code:`opencmp` module: from the top-level directory, execute :code:`pip3 install .`
+
+4) Optionally, run all the unit tests using :code:`pytesting` from the top-level directory. Note,
 
     * In order to run the tests, all optional dependencies must be installed.
+    
     * For full information about running the tests see the README.md inside the pytests folder.
 
-5) Go through the tutorials and other examples found in the "examples/" folder referring to the `tutorial instructions <https://opencmp.io/tutorials/index.html>`_.
+5) Go through the `tutorials <https://opencmp.io/tutorials/index.html>`_ and other examples found in the "examples/" folder.
+
+
+Custom Commands for OpenCMP
+===========================
+
+**Installing Optional Dependencies**
+
+* :code:`get_optional_dependencies` automatically installs all the optional dependencies.
+
+* :code:`get_pytest` automatically installs the :code:`pytest` python library. 
+
+**Running OpenCMP Test Files**
+
+* :code:`pytesting` from the top-level directory runs all the pytests. 
+
 
 Dependencies
-------------
+============
+
 **Required**
 
-* Python 3.7+
-* NGSolve version 6.2.2105 or later (`link <https://ngsolve.org/downloads>`_)
-* configparser (:code:`pip3 install configparser`)
-* pyparsing (:code:`pip3 install pyparsing`)
+* Python 3.7+ 
 
 **Optional**
 
@@ -42,3 +70,54 @@ Dependencies
 * pytest (:code:`pip3 install pytest`)
 
     * Needed for the unit tests.
+
+Supplementary Information
+=========================
+
+**WSL (Windows Subsystem for Linux)**
+
+* WSL (Windows Subsystem for Linux) is the recommended platform for OpenCMP for native Windows users.
+
+* To install WSL, go to the `Microsoft Store <ms-windows-store://home>`_. Install Ubuntu 20.04 or 22.04.
+
+* Python 3.7+ should come pre-installed. To check this, execute :code:`python3 --version`.
+
+**Setting up WSL for OpenCMP**
+
+* To be able to use the `custom commands for OpenCMP <#custom-commands-for-opencmp>`_, please perform the following. 
+
+    * In WSL, execute :code:`nano ~/.bashrc`
+
+    * At the bottom of the file append the line :code:`export PATH="/home/user/.local/bin:$PATH"` where :code:`user` is the username of your WSL unix profile.
+
+    * Press :code:`CTRL+S` then :code:`CTRL+X`. Exit WSL and restart the application. 
+
+* Ngsolve, a required dependency for OpenCMP, has a graphics issue for WSL. To correct this, execute :code:`sudo apt install ubuntu-desktop`
+
+    * This installs a windows manager for WSL that will allow ngsolve to function correctly.
+
+**Installing an X Server on WSL**
+
+* WSL does not come with GUI (graphical user interface) application support (shortformed an "X server"). To view output plots or any graphical interface, perform the following.
+
+    * Change display variables in WSL.
+    
+        * Execute :code:`nano ~/.bashrc`. At the bottom of the page, append :code:`export DISPLAY=$(ip route list default | awk '{print $3}'):0` and :code:`export LIBGL_ALWAYS_INDIRECT=1` (on separate lines).
+
+        * Press :code:`CTRL+S` then :code:`CTRL+X`. Exit WSL and restart the application.
+    
+    * Enable Public Access on your X11 server for Windows. Follow the tutorial `here <https://skeptric.com/wsl2-xserver/>`_. Be sure to only follow the section "Allow WSL Access via Windows Firewall".
+
+    * Download `VcXsrv https://sourceforge.net/projects/vcxsrv/>`_. Then:
+    
+        * Navigate to :code:`C:\Program Files\VcXsrv` and open :code:`xlaunch.exe`. Click Next until "Extra Settings" page.
+
+        * Be sure to check the box for "Disable Access Control". Save the configuration file somewhere useful.
+
+        * When you want to see visuals in WSL (i.e., :code:`matplotlib` or other outputs/plots), be sure to double click the config.xlaunch you just created before executing the code!
+
+
+
+
+
+

--- a/opencmp/entry_points.py
+++ b/opencmp/entry_points.py
@@ -1,0 +1,76 @@
+# Entry points (console commands) for OpenCMP
+
+import os, sys, platform, time
+from typing import Dict, Optional, cast
+from .models import get_model_class
+from .solvers import get_solver_class
+from .helpers.error_analysis import h_convergence, p_convergence
+from .helpers.error import calc_error
+from .config_functions import ConfigParser
+import pyngcore as ngcore
+from ngsolve import ngsglobals
+from .helpers.post_processing import sol_to_vtu, PhaseFieldModelMimic
+from .run import run
+
+def run_opencmp():
+    """
+    Main function that runs OpenCMP.
+
+    Args (from command line):
+        config_file_path: Filename of the config file to load. Required parameter.
+        config_parser: Optionally provide the ConfigParser if running tests. Optional parameter.
+    """
+    
+    # Arguments for command line use
+
+    config_parser = None
+
+    if len(sys.argv) == 1: # if user did not provide any configuration path (which is required)
+        print("ERROR: Provide configuration file path.")
+        exit(0)
+
+    elif len(sys.argv) == 2: # if user did provide a configuration path
+        config_file_path = sys.argv[1]
+        config_parser = ConfigParser(config_file_path)
+
+    elif len(sys.argv) == 3: # if the user provided both config path and optional config_parser argument
+        config_file_path = sys.argv[1]
+        config_parser = sys.argv[2]
+        config_parser = cast(ConfigParser, config_parser)    
+    
+    else: # if the user provides more than 2 arguments. Print error messages and quit.
+        print('ERROR: More than two arguments were provided.')
+        print('\tOpenCMP supports up to two (2) arguments. The first argument is a required configuration file path.')
+        print('\tThe second argument is the optional ConfigParser if running tests.')
+        print('\tPlease re-try using only 1 or 2 arguments as described above. Thank you.')
+        exit(0)
+
+    # call the function in run.py
+    run(config_file_path, config_parser)
+
+    return
+
+# Entry point 1: install all optional dependencies for OpenCMP: edit, tabulate, pytest
+def install_optional_dependencies():
+    
+    print("Now installing OpenCMP optional dependencies: edt, tabulate, pytest.")
+    os.system("pip3 install edt tabulate pytest")
+
+
+# Entry point 2: short form command to run the pytests... instead of doing python -m pytest pytests/
+def pytest_tests():
+    
+    print("Now will run the pytests...")
+
+    user_os = str(platform.system())
+
+    if user_os == 'Windows':
+        os.system("py -m pytest pytests//")
+    
+    else: # macOS or linux (and WSL)
+        os.system("python3 -m pytest pytests//")
+
+# Entry point 3: install pytest...
+def install_pytest():
+
+    os.system("pip3 install pytest")

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,16 +14,22 @@ classifiers =
 zip_safe = False
 include_package_data = False
 packages = find:
-scripts =
 install_requires =
-    numpy
-    scipy
+    numpy;python_version>'3.7.0'
+    scipy;python_version>'3.7.0'
+    ngsolve;python_version>'3.7.0'
+    configparser;python_version>'3.7.0'
+    pyparsing;python_version>'3.7.0'
 
 [options.package_data]
 
 
 [options.entry_points]
-console_scripts =
+console_scripts = 
+    get_optional_dependencies = opencmp.entry_points:install_optional_dependencies
+    get_pytest = opencmp.entry_points:install_pytest
+    pytesting = opencmp.entry_points:pytest_tests
+    opencmp = opencmp.entry_points:run_opencmp
 
 [options.extras_require]
 


### PR DESCRIPTION
### CHANGES

**Setup.cfg** - automatic required dependency installation and entry point support. Entry points are command line accessible tools. Now users can do `opencmp config` instead of `python3 -m opencmp config` to run the module.

**Entry_points.py** contains the functions for the entry points found in setup.cfg. 

**Installation_guide.rst.** Found in Docs -> getting_started -> installation_guide.rst. Drastically changed to contain new installation information based on entry point functionality as well as WSL support for OpenCMP. Guidelines for each OS (Linux, Windows, macOS) also updated for OpenCMP usage on these platforms.