### PR TITLE
Optional dependency handling via extras_require and installation_guide.rst updates

### DIFF
--- a/docs/getting_started/installation_guide.rst
+++ b/docs/getting_started/installation_guide.rst
@@ -25,7 +25,9 @@ Installing OpenCMP
     
     * Windows - We recommend using `WSL <#supplementary-information>`_ (Windows Subsystem for Linux).
 
-3) Install the :code:`opencmp` module: from the top-level directory, execute :code:`pip3 install .`
+3) Install the :code:`opencmp` module from the top-level directory: :code:`pip3 install .`
+
+    * Install with optional dependencies `here <#dependencies>`_.
 
 4) Optionally, run all the unit tests using :code:`pytesting` from the top-level directory. Note,
 
@@ -35,20 +37,16 @@ Installing OpenCMP
 
 5) Go through the `tutorials <https://opencmp.io/tutorials/index.html>`_ and other examples found in the "examples/" folder.
 
-
 Custom Commands for OpenCMP
 ===========================
 
-**Installing Optional Dependencies**
+**Using OpenCMP**
 
-* :code:`get_optional_dependencies` automatically installs all the optional dependencies.
+* :code:`opencmp` can be run using :code:`opencmp config` instead of :code:`python3 -m opencmp config`, where :code:`config` is the name of the configuration file.
 
-* :code:`get_pytest` automatically installs the :code:`pytest` python library. 
+**Running OpenCMP Unit Tests**
 
-**Running OpenCMP Test Files**
-
-* :code:`pytesting` from the top-level directory runs all the pytests. 
-
+* :code:`pytesting` from the top-level directory runs all the pytests. All optional dependencies must be installed.
 
 Dependencies
 ============
@@ -59,26 +57,41 @@ Dependencies
 
 **Optional**
 
-* edt (:code:`pip3 install edt`)
+* :code:`edt` - Needed for the Diffuse Interface Method.
 
-    * Needed for the Diffuse Interface Method.
+* :code:`tabulate` - Needed to output results for mesh refinement and polynomial order convergence tests.
 
-* tabulate (:code:`pip3 install tabulate`)
+* :code:`pytest` - Needed for the unit tests.
 
-    * Needed to output results for mesh refinement and polynomial order convergence tests.
+* :code:`pytest-xdist` - requires :code:`pytest`. Can distribute tests across multiple CPUs to speed up test execution.
+.. list-table::
+    :widths: 25 25
+    :header-rows: 1
 
-* pytest (:code:`pip3 install pytest`)
+    * - Command (from top-level directory)
+      - Dependencies Installed
+    * - :code:`pip3 install .[all]`
+      - :code:`edt` :code:`tabulate` :code:`pytest` :code:`pytest-xdist`
+    * - :code:`pip3 install .[edt]`
+      - :code:`edt`
+    * - :code:`pip3 install .[tab]`
+      - :code:`tabulate`
+    * - :code:`pip3 install .[test]`
+      - :code:`pytest`
+    * - :code:`pip3 install .[test_ext]`
+      - :code:`pytest` :code:`pytest-xdist`
 
-    * Needed for the unit tests.
+* To install :code:`opencmp` with more than one dependency argument: :code:`pip3 install .[x,y]`
+
 
 Supplementary Information
 =========================
 
 **WSL (Windows Subsystem for Linux)**
 
-* WSL (Windows Subsystem for Linux) is the recommended platform for OpenCMP for native Windows users.
+* WSL is the recommended platform for native Windows users to use OpenCMP.
 
-* To install WSL, go to the `Microsoft Store <ms-windows-store://home>`_. Install Ubuntu 20.04 or 22.04.
+* To install WSL, go to the `Microsoft Store <ms-windows-store://home>`_. Install Ubuntu 20.04 LTS.
 
 * Python 3.7+ should come pre-installed. To check this, execute :code:`python3 --version`.
 
@@ -92,9 +105,7 @@ Supplementary Information
 
     * Press :code:`CTRL+S` then :code:`CTRL+X`. Exit WSL and restart the application. 
 
-* Ngsolve, a required dependency for OpenCMP, has a graphics issue for WSL. To correct this, execute :code:`sudo apt install ubuntu-desktop`
-
-    * This installs a windows manager for WSL that will allow ngsolve to function correctly.
+* :code:`ngsolve`, a required dependency for OpenCMP, has a graphics issue for WSL. To correct this, install a windows manager via :code:`sudo apt install ubuntu-desktop`
 
 **Installing an X Server on WSL**
 
@@ -108,14 +119,11 @@ Supplementary Information
     
     * Enable Public Access on your X11 server for Windows. Follow the tutorial `here <https://skeptric.com/wsl2-xserver/>`_. Be sure to only follow the section "Allow WSL Access via Windows Firewall".
 
-    * Download `VcXsrv https://sourceforge.net/projects/vcxsrv/>`_. Then:
+    * Download `VcXsrv <https://sourceforge.net/projects/vcxsrv/>`_. Navigate to :code:`C:\Program Files\VcXsrv` and open :code:`xlaunch.exe`. 
     
-        * Navigate to :code:`C:\Program Files\VcXsrv` and open :code:`xlaunch.exe`. Click Next until "Extra Settings" page.
-
-        * Be sure to check the box for "Disable Access Control". Save the configuration file somewhere useful.
-
-        * When you want to see visuals in WSL (i.e., :code:`matplotlib` or other outputs/plots), be sure to double click the config.xlaunch you just created before executing the code!
-
+        * Click Next until "Extra Settings" page. Check the box for "Disable Access Control". 
+        
+        * Save the configuration file somewhere useful. Ensure that you run the :code:`config.xlaunch` file before executing code with any graphical output.
 
 
 

--- a/opencmp/entry_points.py
+++ b/opencmp/entry_points.py
@@ -1,15 +1,21 @@
-# Entry points (console commands) for OpenCMP
+########################################################################################################################
+# Copyright 2021 the authors (see AUTHORS file for full list).                                                         #
+#                                                                                                                      #
+# This file is part of OpenCMP.                                                                                        #
+#                                                                                                                      #
+# OpenCMP is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public  #
+# License as published by the Free Software Foundation, either version 2.1 of the License, or (at your option) any     #
+# later version.                                                                                                       #
+#                                                                                                                      #
+# OpenCMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied        #
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more  #
+# details.                                                                                                             #
+#                                                                                                                      #
+# You should have received a copy of the GNU Lesser General Public License along with OpenCMP. If not, see             #
+# <https://www.gnu.org/licenses/>.                                                                                     #
+########################################################################################################################
 
-import os, sys, platform, time
-from typing import Dict, Optional, cast
-from .models import get_model_class
-from .solvers import get_solver_class
-from .helpers.error_analysis import h_convergence, p_convergence
-from .helpers.error import calc_error
-from .config_functions import ConfigParser
-import pyngcore as ngcore
-from ngsolve import ngsglobals
-from .helpers.post_processing import sol_to_vtu, PhaseFieldModelMimic
+import os, sys, platform
 from .run import run
 
 def run_opencmp():
@@ -18,12 +24,10 @@ def run_opencmp():
 
     Args (from command line):
         config_file_path: Filename of the config file to load. Required parameter.
-        config_parser: Optionally provide the ConfigParser if running tests. Optional parameter.
+
     """
     
     # Arguments for command line use
-
-    config_parser = None
 
     if len(sys.argv) == 1: # if user did not provide any configuration path (which is required)
         print("ERROR: Provide configuration file path.")
@@ -31,33 +35,19 @@ def run_opencmp():
 
     elif len(sys.argv) == 2: # if user did provide a configuration path
         config_file_path = sys.argv[1]
-        config_parser = ConfigParser(config_file_path)
 
-    elif len(sys.argv) == 3: # if the user provided both config path and optional config_parser argument
-        config_file_path = sys.argv[1]
-        config_parser = sys.argv[2]
-        config_parser = cast(ConfigParser, config_parser)    
-    
-    else: # if the user provides more than 2 arguments. Print error messages and quit.
-        print('ERROR: More than two arguments were provided.')
-        print('\tOpenCMP supports up to two (2) arguments. The first argument is a required configuration file path.')
-        print('\tThe second argument is the optional ConfigParser if running tests.')
-        print('\tPlease re-try using only 1 or 2 arguments as described above. Thank you.')
+    else: # if the user provides more than 1 argument (in addition to opencmp). Print error messages and quit.
+        print('ERROR: More than one argument was provided.')
+        print('** OpenCMP supports up to one (1) argument. The argument is a required configuration file path.')
+        print('Please re-try with "opencmp config" where "config" is the name of the configuration file in the current directory. **')
         exit(0)
 
     # call the function in run.py
-    run(config_file_path, config_parser)
+    run(config_file_path)
 
     return
 
-# Entry point 1: install all optional dependencies for OpenCMP: edit, tabulate, pytest
-def install_optional_dependencies():
-    
-    print("Now installing OpenCMP optional dependencies: edt, tabulate, pytest.")
-    os.system("pip3 install edt tabulate pytest")
 
-
-# Entry point 2: short form command to run the pytests... instead of doing python -m pytest pytests/
 def pytest_tests():
     
     print("Now will run the pytests...")
@@ -69,8 +59,3 @@ def pytest_tests():
     
     else: # macOS or linux (and WSL)
         os.system("python3 -m pytest pytests//")
-
-# Entry point 3: install pytest...
-def install_pytest():
-
-    os.system("pip3 install pytest")

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,11 +26,23 @@ install_requires =
 
 [options.entry_points]
 console_scripts = 
-    get_optional_dependencies = opencmp.entry_points:install_optional_dependencies
-    get_pytest = opencmp.entry_points:install_pytest
     pytesting = opencmp.entry_points:pytest_tests
     opencmp = opencmp.entry_points:run_opencmp
 
 [options.extras_require]
-
+test = 
+    pytest;python_version>'3.7'
+test_ext =
+    pytest;python_version>'3.7'
+    pytest-xdist;python_version>'3.7'
+tab =
+    tabulate;python_version>'3.7'
+edt =
+    edt;python_version>'3.7'
+all =
+    pytest;python_version>'3.7'
+    pytest-xdist;python_version>'3.7'
+    tabulate;python_version>'3.7'
+    edt;python_version>'3.7'
+    
 [options.packages.find]


### PR DESCRIPTION
**May 28 Changes by mptino**

*Setup.cfg*
- removed optional dependency handling via entry points
- added optional dependency handling via :code:`extras_require` in :code:`setuptools`. 

*Entry_points.py*
- Removed second parameter since this was incorrect to begin with (cannot pass ConfigParser object via command line)
- Added licensing header to top of file

*Installation_guide.rst*
- Changes reflect modifications in both setup.cfg and entry_points.py. Mostly to do with optional dependency handling
