### PR TITLE
Extract nonlinear mixing strategies from BaseSolver

### DIFF
--- a/opencmp/solvers/base_solver.py
+++ b/opencmp/solvers/base_solver.py
@@ -33,6 +33,7 @@ from ..helpers.saving import SolutionFileSaver
 from ..helpers.error import calc_error
 from ..helpers.ngsolve_ import gridfunction_rigid_body_motion
 from ..controllers.controller_group import ControllerGroup
+from .nonlinear_mixing import make_mixer
 
 """
 Module for the base solver class.
@@ -533,28 +534,12 @@ class Solver(ABC):
             self.num_iterations = 0
 
 
-            ########################################################################################################
-            # Default optional user config parameters needed for the nonlinear solvers
-            # TODO: eventually this is moved to the config file, but is here temporarily
-
-            ## LinearMixing, DiagBroyden, and Anderson ##
-            alpha = 1.0 # related to jacobian approximation via J ~ -1/alpha
-
-            ## Anderson Mixing ##
-            keep_vectors = 5 # number of difference vectors to retain. Default is 4 or 5
-            w0 = 0.01 # parameter for numerical stability. Good values on order of 0.01. Default 0.01.
-            singular_tolerance = 1e-6 # the tolerance for singular matrix
-
-
-            ########################################################################################################
-
             # initialize the dx and f vector. No need to populate data, this is done later
             dx = self.gfu.vec.Copy()
             f = self.gfu.vec.Copy()
 
-            ##################################################################################################################
+            _mixer = make_mixer(self.nonlinear_solver)
 
-            # Iteration begins here. until we have converged (and reached an acceptable solution), then
             while True:
 
                 ########################################################################################################
@@ -595,125 +580,18 @@ class Solver(ABC):
                         sys.exit(-1)
 
 
-                ########################################################################################################
-
-                # Begin nonlinear solver iteration
-
-                # i = 1
-                # for the first iteration, simply use linearized solution instead of mixing
                 if self.num_iterations == 1:
-
-                    # initialize x_prev and x_curr and populate with initial data
                     x_prev = self.gfu.vec.Copy()
                     x_prev.data = self.gfu.vec
                     x_curr = self.gfu.vec.Copy()
                     x_curr.data = self.gfu.vec
-
-
-                # i > 1
-                # for the remaining iterations, perform a nonlinear solve
                 else:
-
-                    ############################################################################################
-
-                    # Populate the f vector using current guess (linearization) minus previous
                     f.data = self.gfu.vec - x_prev
-                    fcurr = f.FV().NumPy().copy()
-
-                    # Initialize other parameters needed for nonlinear solvers
-                    if self.num_iterations == 2:
-
-                        # Initialize alpha
-                        # TODO: must handle this after implementing alpha into config file and finding
-                        # a citation or reference for this estimate and ITS BOUNDS
-                        # there is no citation for this from the Scipy linear_mixing solver code, but it seems to be based
-                        # on the "dominent eigenvalue method" (reference needed!)
-                        # based on Scipy implementation and information from the DEM method, alpha should not exceed 1
-                        # for stability.
-                        alpha = min(1., 0.5 * max(1., x_prev.Norm()) / f.Norm())
-
-                        # Keep track of previous f
-                        fprev = fcurr.copy()
-
-                        # If DiagBroyden, initialize beta
-                        # TODO: needs to be made thread efficient; currently repeated by every thread
-                        if self.nonlinear_solver == 'DiagBroyden':
-                            beta = np.full((self.gfu.vec.size), 1/alpha)
-
-                    ############################################################################################
-                    # Perform mixing here based on the nonlinear solver chosen
-                    # Note: all solvers perform linear mixing for first (i=1) iteration
-
-                    if self.nonlinear_solver == 'LinearMixing' or self.num_iterations == 2:
-                        dx.data = alpha * f.Copy()
-                        if self.nonlinear_solver in ['default', 'Anderson']:
-                            dx_all = []
-                            df_all = []
-                            dx_all.append(dx.FV().NumPy().copy())
-
-                    elif self.nonlinear_solver == 'DiagBroyden':
-                        # Jacobian update
-                        beta -= (fcurr-fprev + beta*dx.FV().NumPy().copy())  *  dx.FV().NumPy().copy() / dx.Norm()**2
-                        # update dx and fprev
-                        dx.data = f.FV().NumPy().copy() / beta
-                        fprev = fcurr.copy()
-
-                    elif self.nonlinear_solver in ['default', 'Anderson']:
-                        # first must populate df_all with difference vector, fi+1-f_i
-                        df_all.append(fcurr-fprev)
-                        fprev = fcurr.copy()
-
-                        # if we are retaining more vectors than what has been set, remove the oldest one
-                        if len(dx_all) > keep_vectors:
-                            dx_all.pop(0)
-                            df_all.pop(0)
-
-                        # create the A matrix which is used to update dx during full anderson mixing
-                        A = np.zeros((len(dx_all), len(dx_all)))
-                        for i in range(len(dx_all)):
-                            for j in range(i,len(dx_all)):
-                                A[i,j] = np.vdot(df_all[i], df_all[j])
-
-                        np.fill_diagonal(A, A.diagonal() * (1+w0**2)) # multiply diagonal by 1+w0**2
-                        A += np.triu(A, 1).T.conj() # add to A, the transposed upper triangular (below 1st diag) matrix
-
-                        # check to see if A is singular. if so, reset jacobian approximation
-                        if abs(np.linalg.det(A)) < singular_tolerance:
-                            dx_all = []
-                            df_all = []
-                            dx.data = alpha * f.Copy()
-                            dx_all.append(dx.FV().NumPy().copy())
-
-                        # If A not singular, then perform full anderson mixing!
-                        else:
-                            dx.data = -alpha * f.Copy()
-                            dff = np.zeros(len(df_all))
-                            for k in range(len(df_all)):
-                                dff[k] = np.vdot(df_all[k], fcurr)
-
-                            gamma = np.linalg.solve(A, dff)
-                            dx_np = dx.FV().NumPy().copy()
-                            for k in range(len(df_all)):
-                                dx_np += gamma[k] * (dx_all[k] + alpha*df_all[k])
-
-                            # Adjust dx_np and then set it to dx for next update
-                            dx.data = -1 * dx_np.copy()
-                            dx_all.append(dx.FV().NumPy().copy())
-
-
-                    # update the current guess, the x_curr vector via the Newton method
+                    dx.data = _mixer.step(f, x_prev, self.num_iterations)
                     x_curr.data += dx
 
-                ############################################################################################
-                # Below is code that is executed for all iterations (i = 0 : self.nonlinear_max_iterations)
-
-                # update grid function vector (in-place) for next iteration
                 self.gfu.vec.data = x_curr
-
-                # update the previous x
                 x_prev.data = x_curr
-
-                # see if the current solution is acceptable
                 self.model.update_linearization(self.gfu)
 
 

--- a/opencmp/solvers/nonlinear_mixing.py
+++ b/opencmp/solvers/nonlinear_mixing.py
@@ -1,0 +1,141 @@
+"""
+Nonlinear mixing strategies for the stationary inexact Newton iteration in base_solver._solve().
+
+Each mixer owns the per-iteration state for its scheme (alpha, history vectors, etc.) and
+exposes a single step(f_vec, x_prev_vec, num_iterations) -> np.ndarray call.  The loop in
+_solve() is responsible for everything else (BC application, re-assembly, convergence checks,
+gfu/x_curr updates).
+
+All three schemes follow the same first-step convention as the original code: on iteration 2
+(the first real mixing step) every scheme performs linear mixing and initialises alpha from
+the dominant-eigenvalue estimate.  Scheme-specific logic takes over from iteration 3 onward.
+"""
+
+import numpy as np
+import numpy.linalg as npl
+from ngsolve import BaseVector
+
+
+class LinearMixing:
+    """dx = alpha * f  (constant Jacobian approximation J ~ -1/alpha)."""
+
+    def __init__(self, alpha: float = 1.0, **_) -> None:
+        self._alpha = alpha
+
+    def step(self, f_vec: BaseVector, x_prev_vec: BaseVector, num_iterations: int) -> np.ndarray:
+        if num_iterations == 2:
+            # TODO: must handle this after implementing alpha into config file and finding
+            # a citation or reference for this estimate and ITS BOUNDS
+            # there is no citation for this from the Scipy linear_mixing solver code, but it seems to be based
+            # on the "dominent eigenvalue method" (reference needed!)
+            # based on Scipy implementation and information from the DEM method, alpha should not exceed 1
+            # for stability.
+            self._alpha = min(1., 0.5 * max(1., x_prev_vec.Norm()) / f_vec.Norm())
+        return self._alpha * f_vec.FV().NumPy().copy()
+
+
+class DiagBroyden:
+    """Diagonal Broyden update: beta is a vector-valued inverse-Jacobian diagonal."""
+
+    def __init__(self, alpha: float = 1.0, **_) -> None:
+        self._alpha = alpha
+        self._fprev: np.ndarray = None
+        self._beta: np.ndarray = None
+        self._dx_prev_np: np.ndarray = None
+
+    def step(self, f_vec: BaseVector, x_prev_vec: BaseVector, num_iterations: int) -> np.ndarray:
+        fcurr = f_vec.FV().NumPy().copy()
+        if num_iterations == 2:
+            self._alpha = min(1., 0.5 * max(1., x_prev_vec.Norm()) / f_vec.Norm())
+            self._fprev = fcurr.copy()
+            # TODO: needs to be made thread efficient; currently repeated by every thread
+            self._beta = np.full(f_vec.size, 1.0 / self._alpha)
+            dx_np = self._alpha * fcurr
+        else:
+            # Jacobian update
+            dx_prev = self._dx_prev_np
+            self._beta -= (fcurr - self._fprev + self._beta * dx_prev) * dx_prev / npl.norm(dx_prev) ** 2
+            dx_np = fcurr / self._beta
+            self._fprev = fcurr.copy()
+        self._dx_prev_np = dx_np.copy()
+        return dx_np
+
+
+class Anderson:
+    """
+    Anderson mixing (Eyert, J. Comp. Phys. 124, 271 (1996)).
+
+    Retains keep_vectors difference vectors (dx_all, df_all) and constructs a
+    weighted combination to accelerate convergence.  Falls back to linear mixing
+    when the history matrix A is singular.
+    """
+
+    def __init__(self, alpha: float = 1.0, keep_vectors: int = 5,
+                 w0: float = 0.01, singular_tolerance: float = 1e-6) -> None:
+        self._alpha = alpha
+        self._keep_vectors = keep_vectors
+        self._w0 = w0
+        self._singular_tolerance = singular_tolerance
+        self._fprev: np.ndarray = None
+        self._dx_all: list = []
+        self._df_all: list = []
+
+    def step(self, f_vec: BaseVector, x_prev_vec: BaseVector, num_iterations: int) -> np.ndarray:
+        fcurr = f_vec.FV().NumPy().copy()
+
+        if num_iterations == 2:
+            self._alpha = min(1., 0.5 * max(1., x_prev_vec.Norm()) / f_vec.Norm())
+            self._fprev = fcurr.copy()
+            dx_np = self._alpha * fcurr
+            self._dx_all = [dx_np.copy()]
+            self._df_all = []
+            return dx_np
+
+        # num_iterations > 2: full Anderson mixing
+        self._df_all.append(fcurr - self._fprev)
+        self._fprev = fcurr.copy()
+
+        if len(self._dx_all) > self._keep_vectors:
+            self._dx_all.pop(0)
+            self._df_all.pop(0)
+
+        A = np.zeros((len(self._dx_all), len(self._dx_all)))
+        for i in range(len(self._dx_all)):
+            for j in range(i, len(self._dx_all)):
+                A[i, j] = np.vdot(self._df_all[i], self._df_all[j])
+        np.fill_diagonal(A, A.diagonal() * (1 + self._w0 ** 2))
+        A += np.triu(A, 1).T.conj()
+
+        if abs(npl.det(A)) < self._singular_tolerance:
+            # reset jacobian approximation
+            self._dx_all = []
+            self._df_all = []
+            dx_np = self._alpha * fcurr
+            self._dx_all.append(dx_np.copy())
+        else:
+            dx_np = -self._alpha * fcurr
+            dff = np.array([np.vdot(self._df_all[k], fcurr) for k in range(len(self._df_all))])
+            gamma = npl.solve(A, dff)
+            for k in range(len(self._df_all)):
+                dx_np += gamma[k] * (self._dx_all[k] + self._alpha * self._df_all[k])
+            dx_np = -1 * dx_np
+            self._dx_all.append(dx_np.copy())
+
+        return dx_np
+
+
+_SCHEMES = {
+    'LinearMixing': LinearMixing,
+    'DiagBroyden':  DiagBroyden,
+    'Anderson':     Anderson,
+    'default':      Anderson,
+}
+
+
+def make_mixer(name: str, alpha: float = 1.0, keep_vectors: int = 5,
+               w0: float = 0.01, singular_tolerance: float = 1e-6):
+    """Return the mixer instance for the given nonlinear_solver config value."""
+    if name not in _SCHEMES:
+        raise ValueError(f"Unknown nonlinear_solver '{name}'. Choose from: {list(_SCHEMES)}")
+    return _SCHEMES[name](alpha=alpha, keep_vectors=keep_vectors,
+                          w0=w0, singular_tolerance=singular_tolerance)

--- a/pytests/full_system/ins/test_nonlinear_mixer_refactor.py
+++ b/pytests/full_system/ins/test_nonlinear_mixer_refactor.py
@@ -1,0 +1,36 @@
+"""
+Characterization tests for the nonlinear mixer extraction refactor.
+
+All three schemes (Anderson/default, LinearMixing, DiagBroyden) must converge to
+the same solution on the pipe-flow case.  Expected errors are the same as those
+in test_ins.py for the CG case — the nonlinear solver scheme affects the path to
+convergence, not the converged solution itself.
+
+If any test here fails after a code change, the mixing math diverged from the
+pre-refactor behaviour.
+"""
+
+import pytest
+from pytest import CaptureFixture, fixture
+from opencmp.helpers.testing import automated_output_check
+from opencmp.config_functions import ConfigParser
+
+EXPECTED_ERRORS = [2e-7, 5e-8, 1.5e-4, 3.5e-5]
+
+
+@fixture
+def pipe_velocity_flow() -> ConfigParser:
+    return ConfigParser('pytests/full_system/ins/pressure_flow_in_pipe_velocity/config')
+
+
+class TestNonlinearMixerRefactor:
+    def test_anderson_default(self, capsys: CaptureFixture, pipe_velocity_flow: ConfigParser) -> None:
+        automated_output_check(capsys, pipe_velocity_flow, EXPECTED_ERRORS)
+
+    def test_linear_mixing(self, capsys: CaptureFixture, pipe_velocity_flow: ConfigParser) -> None:
+        pipe_velocity_flow['SOLVER']['nonlinear_solver'] = 'LinearMixing'
+        automated_output_check(capsys, pipe_velocity_flow, EXPECTED_ERRORS)
+
+    def test_diag_broyden(self, capsys: CaptureFixture, pipe_velocity_flow: ConfigParser) -> None:
+        pipe_velocity_flow['SOLVER']['nonlinear_solver'] = 'DiagBroyden'
+        automated_output_check(capsys, pipe_velocity_flow, EXPECTED_ERRORS)


### PR DESCRIPTION
This PR extracts the nonlinear mixing implementations from `BaseSolver._solve()`
  into a dedicated `nonlinear_mixing.py` module.

  The refactor:

  - Separates nonlinear mixing logic from the main solver loop.
  - Introduces a common interface for constructing the configured mixing strategy.
  - Preserves the existing nonlinear-solver behavior.
  - Adds focused regression tests for the supported mixing methods.


`BaseSolver._solve()` previously contained both the general nonlinear iteration
  workflow and the implementation details of individual mixing strategies. This
  made the solver loop difficult to read, test, and extend. In the new code:

  - `BaseSolver` manages the nonlinear solve.
  - The mixing module manages updates to the nonlinear iterate.

