### PR TITLE
Improve configuration and CLI diagnostics

### DIFF
--- a/opencmp/config_functions/expanded_config_parser.py
+++ b/opencmp/config_functions/expanded_config_parser.py
@@ -251,6 +251,21 @@ class ConfigParser(configparser.ConfigParser):
         keys_one = [item for item in self.sections() if item not in ignore]
 
         if white_list:
+            white_list_upper = {w.upper(): w for w in white_list}
+
+            for item in self.sections():
+                if item in ignore:
+                    continue
+                if item not in white_list and item.upper() in white_list_upper:
+                    expected = white_list_upper[item.upper()]
+                    raise ValueError(
+                        f"\nConfig section '[{item}]' was not recognized, but it looks like a case mismatch for '[{expected}]'. \nSection headers are case-sensitive, please rename '[{item}]' to '[{expected}]' in your config file."
+                    )
+                elif item not in white_list:
+                    raise ValueError(
+                        f"\nInvalid config section '[{item}]'."
+                    )
+
             keys_one = [item for item in keys_one if item in white_list]
 
         # Top level dictionaries

--- a/opencmp/config_functions/expanded_config_parser.py
+++ b/opencmp/config_functions/expanded_config_parser.py
@@ -254,14 +254,18 @@ class ConfigParser(configparser.ConfigParser):
             white_list_upper = {w.upper(): w for w in white_list}
 
             for item in self.sections():
-                if item in ignore:
+                if item in ignore or item in white_list:
                     continue
-                if item not in white_list and item.upper() in white_list_upper:
+                # Empty sections are harmless boilerplate (e.g. unused BC types left over in a
+                # DIM config template) -- only mistyped/unrecognized sections with actual data are an error.
+                if not list(self[item]):
+                    continue
+                if item.upper() in white_list_upper:
                     expected = white_list_upper[item.upper()]
                     raise ValueError(
                         f"\nConfig section '[{item}]' was not recognized, but it looks like a case mismatch for '[{expected}]'. \nSection headers are case-sensitive, please rename '[{item}]' to '[{expected}]' in your config file."
                     )
-                elif item not in white_list:
+                else:
                     raise ValueError(
                         f"\nInvalid config section '[{item}]'."
                     )

--- a/opencmp/entry_points.py
+++ b/opencmp/entry_points.py
@@ -43,7 +43,11 @@ def run_opencmp():
         exit(0)
 
     # call the function in run.py
-    run(config_file_path)
+    try:
+        run(config_file_path)
+    except KeyboardInterrupt:
+        print()
+        sys.exit(0)
 
     return
 

--- a/opencmp/solvers/base_solver.py
+++ b/opencmp/solvers/base_solver.py
@@ -252,6 +252,9 @@ class Solver(ABC):
 
         self.save_to_file = self.config.get_item(['VISUALIZATION', 'save_to_file'], bool)
 
+        if not self.save_to_file:
+            logging.warning('save_to_file is set to False — no solution files will be written for this run.')
+
         if self.save_to_file:
             self.saver = SolutionFileSaver(self.model, quiet=True)
             save_freq = self.config.get_list(['VISUALIZATION', 'save_frequency'], str, quiet=True)


### PR DESCRIPTION
This PR improves several user-facing warnings and error paths:

  - Report populated configuration sections that are unknown or incorrectly
    capitalized instead of silently ignoring them.
  - Continue accepting empty sections commonly left in configuration templates.
  - Warn when `save_to_file` is disabled and no solution files will be written.
  - Handle `KeyboardInterrupt` cleanly at the command-line entry point without
    printing an unnecessary traceback.

## Motivation

  Several configuration mistakes currently fail silently or produce behavior that
  is difficult to diagnose.

  A misspelled or incorrectly capitalized section can cause OpenCMP to ignore
  user-supplied values and continue with defaults. At the same time, completely
  empty sections are valid template boilerplate and should not cause errors.

  Similarly, disabling solution output should be communicated clearly, and a
  user intentionally stopping a CLI run with `Ctrl+C` should not receive a full
  Python traceback.

  These changes make the resulting behavior explicit while preserving valid
  existing configurations.
